### PR TITLE
Provide add_zserio_cpp_runtime and add_zserio_sqlite3 macros.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,11 +64,12 @@ set_target_properties(${PROJECT_NAME}
 macro(add_zserio_sqlite3)
   add_library(zserio-sqlite3
     STATIC
-      ${ZSERIO_REPO_ROOT}/3rdparty/sqlite/sqlite3.c
-      ${ZSERIO_REPO_ROOT}/3rdparty/sqlite/sqlite3.h)
+      "${ZSERIO_REPO_ROOT}/3rdparty/cpp/sqlite/sqlite3.c"
+      "${ZSERIO_REPO_ROOT}/3rdparty/cpp/sqlite/sqlite3.h")
   target_include_directories(zserio-sqlite3
     PUBLIC
-      "${ZSERIO_REPO_ROOT}/3rdparty/sqlite")
+      "${ZSERIO_REPO_ROOT}/3rdparty/cpp/sqlite")
+  message("zserio-sqlite3 is now available from ${ZSERIO_REPO_ROOT}/3rdparty/cpp/sqlite")
   target_compile_definitions(zserio-sqlite3
     PRIVATE
       SQLITE_ENABLE_FTS4 SQLITE_ENABLE_FTS5)
@@ -78,11 +79,12 @@ macro(add_zserio_sqlite3)
 endmacro()
 
 # Macro to add ZserioCppRuntime
-# If the option WITH_SQLITE is set, add_zserio_sqlite3
+# If the option WITH_SQLITE3 is set, add_zserio_sqlite3
 # will be called, and ZserioCppRuntime will link against it.
 macro(add_zserio_cpp_runtime)
-  cmake_parse_arguments(ZS_RUNTIME WITH_SQLITE3 "" "")
+  cmake_parse_arguments(ZS_RUNTIME "WITH_SQLITE3" "" "" ${ARGV0})
   add_subdirectory("${ZSERIO_REPO_ROOT}/compiler/extensions/cpp/runtime/src")
+  message("Adding zserio cpp runtime from ${ZSERIO_REPO_ROOT}/compiler/extensions/cpp/runtime/src. With SQLite: ${ZS_RUNTIME_WITH_SQLITE3}")
   if (ZS_RUNTIME_WITH_SQLITE3)
     add_zserio_sqlite3()
     target_link_libraries(ZserioCppRuntime PUBLIC zserio-sqlite3)
@@ -104,6 +106,14 @@ endmacro()
 #   WITHOUT_SQL
 #     Set this flag to enable the -withoutSqlCode flag for the
 #     zserio C++ emitter.
+#   WITH_IMPLICIT_ARRAYS
+#     Set this flag to enable the -allowImplicitArrays
+#     flag for the zserio C++ emitter.
+#   WITH_POLYMORPHIC_ALLOC
+#     Set this flag to enable the -setCppAllocator polymorphic
+#     flag for the zserio C++ emitter.
+#   QUIET
+#     Suppress all zserio compiler output.
 #   SHARED
 #     Set this flag to create a shared instead of a static lib.
 #   ROOT [schema-root-dir]
@@ -121,8 +131,9 @@ endmacro()
 #     ENTRY mylib.zs)
 #
 function(add_zserio_library ZS_LIB_NAME)
-  cmake_parse_arguments(PARSE_ARGV 0
-    ZS_LIB "EXCLUDE_FROM_ALL;WITH_REFLECTION;WITHOUT_SQL;SHARED" "ROOT;ENTRY;TOP_LEVEL_PKG" "")
+  cmake_parse_arguments(PARSE_ARGV 0 ZS_LIB
+    "EXCLUDE_FROM_ALL;WITH_REFLECTION;WITHOUT_SQL;SHARED;WITH_IMPLICIT_ARRAYS;QUIET;WITH_POLYMORPHIC_ALLOC"
+    "ROOT;ENTRY;TOP_LEVEL_PKG" "")
 
   # Makes sure zserio C++ runtime is added
   if (NOT TARGET ZserioCppRuntime)
@@ -155,6 +166,9 @@ function(add_zserio_library ZS_LIB_NAME)
   set(zserio_top_level_arg "")
   set(zserio_reflection_arg "")
   set(zserio_sql_arg "")
+  set(zserio_impl_arr_arg "")
+  set(zserio_with_polymorphic_alloc_arg "")
+  set(quiet "")
   if (ZS_LIB_TOP_LEVEL_PKG)
     set(zserio_top_level_arg "-setTopLevelPackage")
   endif()
@@ -164,18 +178,28 @@ function(add_zserio_library ZS_LIB_NAME)
   if (ZS_LIB_WITHOUT_SQL)
     set(zserio_sql_arg "-withoutSqlCode")
   endif()
+  if (ZS_LIB_WITH_IMPLICIT_ARRAYS)
+    set(zserio_impl_arr_arg "-allowImplicitArrays")
+  endif()
+  if (ZS_LIB_QUIET)
+    set(quiet OUTPUT_QUIET ERROR_QUIET)
+  endif()
+  if (ZS_LIB_WITH_POLYMORPHIC_ALLOC)
+    set(zserio_with_polymorphic_alloc_arg "-setCppAllocator" "polymorphic")
+  endif()
 
   message("=> Generating code for zserio library ${ZS_LIB_NAME} ...")
   execute_process(
     COMMAND ${ZSERIO}
       ${zserio_top_level_arg} ${ZS_LIB_TOP_LEVEL_PKG}
-      ${zserio_reflection_arg} ${zserio_sql_arg}
+      ${zserio_reflection_arg} ${zserio_sql_arg} ${zserio_impl_arr_arg} ${zserio_with_polymorphic_alloc_arg}
       -cpp ${ZSERIO_GEN_DIR}
       -src ${ZS_LIB_ROOT}
       ${ZS_LIB_ENTRY}
     COMMAND_ECHO STDOUT
     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
-    RESULT_VARIABLE ZSERIO_RESULT)
+    RESULT_VARIABLE ZSERIO_RESULT
+    ${quiet})
 
   if (NOT ZSERIO_RESULT EQUAL "0")
     message(FATAL_ERROR "/////////// zserio FAILED to generate ${ZS_LIB_NAME} module! ///////////")
@@ -193,12 +217,13 @@ function(add_zserio_library ZS_LIB_NAME)
 
   set_target_properties(${ZS_LIB_NAME} PROPERTIES
     POSITION_INDEPENDENT_CODE YES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED YES
     CXX_EXTENSIONS NO)
 
   target_include_directories(${ZS_LIB_NAME} PUBLIC "${ZSERIO_GEN_DIR}")
-  target_link_libraries(${ZS_LIB_NAME} ZserioCppRuntime)
+  target_link_libraries(${ZS_LIB_NAME} PUBLIC ZserioCppRuntime)
+  target_compile_features (${ZS_LIB_NAME} PUBLIC cxx_std_14)
 
   if (NOT ZS_LIB_EXCLUDE_FROM_ALL)
     add_dependencies(zserio-cmake-helper ${ZS_LIB_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,11 +9,6 @@ if (NOT DEFINED ZSERIO_REPO_ROOT)
   message(FATAL_ERROR "ZSERIO_REPO_ROOT must be set before add_subdirectory(zserio-cmake-helper)!")
 endif()
 
-# Makes sure zserio C++ runtime is added
-if (NOT TARGET ZserioCppRuntime)
-  message(FATAL_ERROR "ZserioCppRuntime target is not available! Did you forget to call add_subdirectory(.../zserio/compiler/extensions/cpp/runtime/src)?")
-endif()
-
 # Find `ant` command to build zserio.jar
 find_program(ANT_PATH NAMES ant)
 if (NOT ANT_PATH)
@@ -65,6 +60,35 @@ set_target_properties(${PROJECT_NAME}
   PROPERTIES
     jar "${ZSERIO_DISTR_DIR}/zserio.jar")
 
+# Macro to add zserio-sqlite3 as shipped under zserio/3rdparty
+macro(add_zserio_sqlite3)
+  add_library(zserio-sqlite3
+    STATIC
+      ${ZSERIO_REPO_ROOT}/3rdparty/sqlite/sqlite3.c
+      ${ZSERIO_REPO_ROOT}/3rdparty/sqlite/sqlite3.h)
+  target_include_directories(zserio-sqlite3
+    PUBLIC
+      "${ZSERIO_REPO_ROOT}/3rdparty/sqlite")
+  target_compile_definitions(zserio-sqlite3
+    PRIVATE
+      SQLITE_ENABLE_FTS4 SQLITE_ENABLE_FTS5)
+  if (UNIX)
+    target_link_libraries(zserio-sqlite3 PUBLIC dl)
+  endif ()
+endmacro()
+
+# Macro to add ZserioCppRuntime
+# If the option WITH_SQLITE is set, add_zserio_sqlite3
+# will be called, and ZserioCppRuntime will link against it.
+macro(add_zserio_cpp_runtime)
+  cmake_parse_arguments(ZS_RUNTIME WITH_SQLITE3 "" "")
+  add_subdirectory("${ZSERIO_REPO_ROOT}/compiler/extensions/cpp/runtime/src")
+  if (ZS_RUNTIME_WITH_SQLITE3)
+    add_zserio_sqlite3()
+    target_link_libraries(ZserioCppRuntime PUBLIC zserio-sqlite3)
+  endif()
+endmacro()
+
 # Function to create a library from zserio schema sources.
 #
 # The following arguments are supported:
@@ -99,6 +123,11 @@ set_target_properties(${PROJECT_NAME}
 function(add_zserio_library ZS_LIB_NAME)
   cmake_parse_arguments(PARSE_ARGV 0
     ZS_LIB "EXCLUDE_FROM_ALL;WITH_REFLECTION;WITHOUT_SQL;SHARED" "ROOT;ENTRY;TOP_LEVEL_PKG" "")
+
+  # Makes sure zserio C++ runtime is added
+  if (NOT TARGET ZserioCppRuntime)
+    message(FATAL_ERROR "ZserioCppRuntime target is not available! Did you forget to call add_zserio_cpp_runtime()?")
+  endif()
 
   if (NOT ZS_LIB_ROOT)
     message(FATAL_ERROR "Missing zserio-module argument ROOT!")

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ add_subdirectory(deps/zserio-cmake-helper)
 add_zserio_cpp_runtime()
 
 # Now ZserioCppRuntime is available as a target.
+# You may also pass WITH_SQLITE3 if you want to
+# link against the sqlite sources that are shipped
+# inside of the zserio repo under 3rdparty/sqlite3.
 ```
 
 **Important: Make sure that `ant` and `java` are available on your system!**
@@ -24,7 +27,6 @@ Otherwise, the above call will fail. Once the `zserio-cmake-helper` directory
 is added, the `add_zserio_library` helper function will be available.
 
 ```cmake
-# Adapt using following parameters:
 #   ZS_LIB_NAME
 #     Must be the first argument. This will be the name of
 #     the newly generated target.
@@ -37,6 +39,14 @@ is added, the `add_zserio_library` helper function will be available.
 #   WITHOUT_SQL
 #     Set this flag to enable the -withoutSqlCode flag for the
 #     zserio C++ emitter.
+#   WITH_IMPLICIT_ARRAYS
+#     Set this flag to enable the -allowImplicitArrays
+#     flag for the zserio C++ emitter.
+#   WITH_POLYMORPHIC_ALLOC
+#     Set this flag to enable the -setCppAllocator polymorphic
+#     flag for the zserio C++ emitter.
+#   QUIET
+#     Suppress all zserio compiler output.
 #   SHARED
 #     Set this flag to create a shared instead of a static lib.
 #   ROOT [schema-root-dir]
@@ -48,7 +58,6 @@ is added, the `add_zserio_library` helper function will be available.
 #   TOP_LEVEL_PKG [pkg-name]
 #     Optional top-level namespace for your schema.
 #
-
 add_zserio_library(mylib WITH_REFLECTION
   ROOT path/to/mylib-schema
   ENTRY mylib.zs)

--- a/README.md
+++ b/README.md
@@ -6,20 +6,17 @@ then be used to generate C++ sources for your schema.
 
 ## Usage
 
-In your project's top-level CMakeLists.txt, make sure that the zserio C++
-runtime subdirectory is already added. You must then set `ZSERIO_REPO_ROOT`
-to the top-level zserio repo path. For example:
+In your project's top-level CMakeLists.txt, set `ZSERIO_REPO_ROOT`
+to the top-level zserio repo path, then add the `zserio_cmake_helper`
+subdirectory, then call `add_zserio_cpp_runtime()`:
 
 ```cmake
 # Assume zserio submodule is cloned under deps/zserio
-add_subdirectory(deps/zserio/compiler/extensions/cpp/runtime/src)
 set(ZSERIO_REPO_ROOT "${CMAKE_CURRENT_LIST_DIR}/deps/zserio")
-```
-
-You can then add this project as a subdirectory:
-
-```cmake
 add_subdirectory(deps/zserio-cmake-helper)
+add_zserio_cpp_runtime()
+
+# Now ZserioCppRuntime is available as a target.
 ```
 
 **Important: Make sure that `ant` and `java` are available on your system!**


### PR DESCRIPTION
Simplify the import of the zserio C++ runtime target, and provide simple means to use the `sqlite3` sources that are shipped with zserio. @fklebert This also means you actually don't need to fetch SQLite3 via Conan, just call `add_zserio_cpp_runtime(WITH_SQLITE3)`.

Note that these changes are backwards-compatible, so you can also still add the ZserioCppRuntime subdirectory manually.