### PR TITLE
Use the zserio supplied build script instead of Ant

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,49 +38,20 @@ elseif(DEFINED ZSERIO_REPO_ROOT)
   message("=> Building zserio.jar from source ...")
   message("=> Using zserio from ${ZSERIO_REPO_ROOT}")
 
-  # Find `ant` command to build zserio.jar
-  find_program(ANT_PATH NAMES ant)
-  if (NOT ANT_PATH)
-    message(FATAL_ERROR "Could not find ant binary!")
-  endif()
-
   # Setup build/install locations for zserio jar files in the CMake build folder
   set(ZSERIO_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/zserio)
   set(ZSERIO_BUILD_DIR ${ZSERIO_OUTPUT_DIR}/build)
   set(ZSERIO_DISTR_DIR ${ZSERIO_OUTPUT_DIR}/distr)
-  set(ZSERIO_ANT_PROPS
-    "-Dzserio.build_dir=${ZSERIO_BUILD_DIR}"
-    "-Dzserio.install_dir=${ZSERIO_DISTR_DIR}"
-    "-Dzserio_extensions.build_dir=${ZSERIO_BUILD_DIR}/compiler/extensions"
-    "-Dzserio_extensions.install_dir=${ZSERIO_DISTR_DIR}/zserio_libs"
-    "-Dzserio_runtimes.build_dir=${ZSERIO_BUILD_DIR}/runtime_libs"
-    "-Dzserio_runtimes.install_dir=${ZSERIO_DISTR_DIR}/runtime_libs"
-    "-Dzserio_core.jar_file=${ZSERIO_BUILD_DIR}/compiler/core/jar/zserio_core.jar")
 
   # Run ant for zserio_core, zserio_cpp and zserio_doc, then bundle into zserio.jar
-  message("=> Running main zserio ant install ...")
+  message("=> Running main zserio install ...")
   execute_process(
-    COMMAND ${ANT_PATH} ${ZSERIO_ANT_PROPS} install
+    COMMAND "${ZSERIO_REPO_ROOT}/scripts/build.sh" cpp doc zserio -o "${ZSERIO_OUTPUT_DIR}"
     WORKING_DIRECTORY "${ZSERIO_REPO_ROOT}"
-    RESULT_VARIABLE ZSERIO_ANT_RESULT)
-  message("=> Running zserio cpp extension ant install ...")
-  execute_process(
-    COMMAND ${ANT_PATH} -f compiler/extensions/cpp ${ZSERIO_ANT_PROPS} install
-    WORKING_DIRECTORY "${ZSERIO_REPO_ROOT}"
-    RESULT_VARIABLE ZSERIO_ANT_RESULT)
-  message("=> Running zserio doc extension ant install ...")
-  execute_process(
-    COMMAND ${ANT_PATH} -f compiler/extensions/doc ${ZSERIO_ANT_PROPS} install
-    WORKING_DIRECTORY "${ZSERIO_REPO_ROOT}"
-    RESULT_VARIABLE ZSERIO_ANT_RESULT)
-  message("=> Running zserio bundle install ...")
-  execute_process(
-    COMMAND ${ANT_PATH} ${ZSERIO_ANT_PROPS} zserio_bundle.install
-    WORKING_DIRECTORY "${ZSERIO_REPO_ROOT}"
-    RESULT_VARIABLE ZSERIO_ANT_RESULT)
+    RESULT_VARIABLE ZSERIO_BUILD_RESULT)
 
   # Make sure the previous commands were successful
-  if (NOT ZSERIO_ANT_RESULT EQUAL "0")
+  if (NOT ZSERIO_BUILD_RESULT EQUAL "0")
     message(FATAL_ERROR "Failed to build zserio.jar in ${ZSERIO_REPO_ROOT}.")
   endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ elseif(DEFINED ZSERIO_REPO_ROOT)
   # Run ant for zserio_core, zserio_cpp and zserio_doc, then bundle into zserio.jar
   message("=> Running main zserio install ...")
   execute_process(
-    COMMAND "${ZSERIO_REPO_ROOT}/scripts/build.sh" cpp doc zserio -o "${ZSERIO_OUTPUT_DIR}"
+    COMMAND "${ZSERIO_REPO_ROOT}/scripts/build.sh" core cpp zserio -o "${ZSERIO_OUTPUT_DIR}"
     WORKING_DIRECTORY "${ZSERIO_REPO_ROOT}"
     RESULT_VARIABLE ZSERIO_BUILD_RESULT)
 
@@ -193,7 +193,7 @@ function(add_zserio_library ZS_LIB_NAME)
   if (NOT DEFINED ZSERIO_VERSION)
     set(ZSERIO_VERSION "any")
   endif()
-  set(NEW_LIB_ENTRY_HASH "${ZSERIO_VERSION}:${NEW_LIB_ENTRY_HASH}")
+  set(NEW_LIB_ENTRY_HASH "${ZSERIO_VERSION}:${NEW_LIB_ENTRY_HASH}:${ARGV}")
 
   # Compare against the stored entry file hash
   set(LIB_ENTRY_HASH_FILE "${ZSERIO_GEN_DIR}/.entry.sha1")
@@ -256,9 +256,9 @@ function(add_zserio_library ZS_LIB_NAME)
     message("=> Generating code for zserio library ${ZS_LIB_NAME} ...")
     execute_process(
       COMMAND ${ZSERIO}
-        ${zserio_args}
         -cpp ${ZSERIO_GEN_DIR}
         -src ${ZS_LIB_ROOT}
+        ${zserio_args}
         ${ZS_LIB_ENTRY}
       COMMAND_ECHO STDOUT
       WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"


### PR DESCRIPTION
Simplifies and fixes the build of a supplied zserio source tree using zserio_cmake_helper by using zserios `build.sh` script. Needs this https://github.com/ndsev/zserio/pull/648/commits/b8bcff27d70927e993ba1bff1b8898c7a819ba50 fix to correctly build the zserio extensions out of tree.