### PR TITLE
Reflect EXTRA_ARGS in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ Once the `zserio-cmake-helper` target is available, you can use the `add_zserio_
 #     is the entry point of your schema.
 #   TOP_LEVEL_PKG [pkg-name]
 #     Optional top-level namespace for your schema.
+#   EXTRA_ARGS
+#     Allows passing additional arguments to the zserio compiler.
 #
 add_zserio_library(mylib WITH_REFLECTION
   ROOT path/to/mylib-schema


### PR DESCRIPTION
Related to #9

Update `README.md` to reflect all arguments for `add_zserio_library` function.

* Add `EXTRA_ARGS` argument description to the `add_zserio_library` function section.
* Mention that `EXTRA_ARGS` allows passing additional arguments to the zserio compiler.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Klebert-Engineering/zserio-cmake-helper/issues/9?shareId=d46ce0b2-4885-48ce-b790-139bc8a41586).